### PR TITLE
Deactivated version mismatch alert temporarily

### DIFF
--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
@@ -28,14 +28,14 @@ spec:
       for: 1h
       labels:
         severity: warning
-    - alert: KubeVersionMismatch
-      annotations:
-        message: There are {{`{{ $value }}`}} different semantic versions of Kubernetes components running.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
-      expr: count(count by (gitVersion) (label_replace(kubernetes_build_info{job!="kube-dns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
-      for: 1h
-      labels:
-        severity: warning
+    # - alert: KubeVersionMismatch
+    #   annotations:
+    #     message: There are {{`{{ $value }}`}} different semantic versions of Kubernetes components running.
+    #     runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
+    #   expr: count(count by (gitVersion) (label_replace(kubernetes_build_info{job!="kube-dns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
+    #   for: 1h
+    #   labels:
+    #     severity: warning
     - alert: KubeClientErrors
       annotations:
         message: Kubernetes API server client '{{`{{ $labels.job }}`}}/{{`{{ $labels.instance }}`}}' is experiencing {{`{{ printf "%0.0f" $value }}`}}% errors.'


### PR DESCRIPTION
J'ai enlevé l'alerte de version mismatch puisque:

1- ça change absolument rien pour nous.
2- ça va se fix lors d'une prochaine update de DigitalOcean vers v1.14 ou v1.15